### PR TITLE
Check manifest in main travis task

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,4 +1,5 @@
 .autotest
+.travis.yml
 History.txt
 Manifest.txt
 README.rdoc

--- a/lib/hoe/travis.rb
+++ b/lib/hoe/travis.rb
@@ -151,13 +151,12 @@ module Hoe::Travis
 
   def define_travis_tasks
     desc "Runs your tests for travis"
-    task :travis => %w[test]
+    task :travis => %w[test check_manifest]
 
     namespace :travis do
       desc "Run by travis-ci after running the default checks"
       task :after => %w[
         travis:fake_config
-        check_manifest
       ]
 
       desc "Run by travis-ci before running the default checks"
@@ -587,4 +586,3 @@ Expected \"git@github.com:[repo].git\" as your remote origin
   end
 
 end
-

--- a/test/test_hoe_travis.rb
+++ b/test/test_hoe_travis.rb
@@ -32,10 +32,10 @@ class TestHoeTravis < MiniTest::Unit::TestCase
     @hoe.define_travis_tasks
 
     travis = Rake::Task['travis']
-    assert_equal %w[test], travis.prerequisites
+    assert_equal %w[test check_manifest], travis.prerequisites
 
     after       = Rake::Task['travis:after']
-    assert_equal %w[travis:fake_config check_manifest], after.prerequisites
+    assert_equal %w[travis:fake_config], after.prerequisites
 
     before      = Rake::Task['travis:before']
     assert_equal %w[install_plugins check_extra_deps], before.prerequisites
@@ -260,4 +260,3 @@ script: rake travis
   end
 
 end
-


### PR DESCRIPTION
Travis won't fail a build for a failing after_script,
but we want a mis-matched manifest file to cause the build to fail
